### PR TITLE
Refactored package installation code to call `package-refresh-contents` at most once.

### DIFF
--- a/configuration.org
+++ b/configuration.org
@@ -114,11 +114,14 @@ down in this file, some are used with the default configuration.
 ** Install packages
 
 #+BEGIN_SRC emacs-lisp
-  (dolist (p my-packages)
-    (unless (package-installed-p p)
-      (package-refresh-contents)
-      (package-install p))
-    (add-to-list 'package-selected-packages p))
+  (let ((package-list-refreshed-p nil))
+    (dolist (p my-packages)
+      (unless (package-installed-p p)
+        (unless package-list-refreshed-p
+          (package-refresh-contents)
+          (setq packge-list-refreshed-p t))
+        (package-install p))
+      (add-to-list 'package-selected-packages p)))
 #+END_SRC
 
 * Default Settings


### PR DESCRIPTION
This speeds up startup by eliminating unnecessary network requests.